### PR TITLE
Remove namespace prefix from `SentenceTransformerModel` cfg loader

### DIFF
--- a/crossfit/backend/torch/hf/model.py
+++ b/crossfit/backend/torch/hf/model.py
@@ -105,4 +105,4 @@ class SentenceTransformerModel(HFModel):
         return SentenceTransformer(self.path_or_name, device="cuda").to(device)
 
     def load_cfg(self):
-        return AutoConfig.from_pretrained("sentence-transformers/" + self.path_or_name)
+        return AutoConfig.from_pretrained(self.path_or_name)


### PR DESCRIPTION
Remove namespace prefix from `SentenceTransformerModel` cfg loader.

The current implementaton restricts the use of `SentenceTransformerModel` to the hugging face models in the `sentence-transformers` namespace. Removing this prefix enables loading from other namespaces e.g. `intfloat/e5-*` or from a local path 