### PR TITLE
add lfs-warning github action for detecting large files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,3 +12,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
+
+  lfs-warning:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ppremk/lfs-warning@v3.2
+        with:
+          filesizelimit: 5MB


### PR DESCRIPTION
Adding a file size check since we have a mirror repo on gitlab and gitlab has a limit of 5MB.

Uses https://github.com/marketplace/actions/lfs-warning.

If a file in a PR is larger than the limit, a warning like [this](https://github.com/edknv/crossfit/pull/1#issuecomment-1796972878) will be commented in the PR.