### PR TITLE
install cudf 23.12

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -13,7 +13,7 @@ jobs:
   gpu-ci:
     runs-on: linux-amd64-gpu-p100-latest-1
     container:
-      image: nvcr.io/nvidian/crossfit-ci:23.10
+      image: nvcr.io/nvidian/crossfit-ci:23.10-cudf23.12
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
       options: --shm-size=1G
@@ -32,7 +32,7 @@ jobs:
   benchmark:
     runs-on: linux-amd64-gpu-p100-latest-1
     container:
-      image: nvcr.io/nvidian/crossfit-ci:23.10
+      image: nvcr.io/nvidian/crossfit-ci:23.10-cudf23.12
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
       options: --shm-size=1G

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -3,6 +3,7 @@ FROM nvcr.io/nvidia/nemo:23.10
 COPY . /tmp/crossfit/
 RUN cd /tmp/crossfit && \
     python3 -m pip install .[pytorch-dev] && \
+    python3 -m pip install -r requirements/gpu.txt --no-cache-dir --extra-index-url https://pypi.nvidia.com && \
     python3 -m pip install beir && \
     rm -r /tmp/crossfit
 

--- a/docker/ci/build_and_push.sh
+++ b/docker/ci/build_and_push.sh
@@ -6,7 +6,7 @@
 set -e
 
 IMAGE_NAME=nvcr.io/nvidian/crossfit-ci
-IMAGE_TAG=23.10
+IMAGE_TAG=23.10-cudf23.12
 
 docker build -t ${IMAGE_NAME}:${IMAGE_TAG} -f docker/ci/Dockerfile .
 


### PR DESCRIPTION
This PR adds cudf 23.12 as requirement since nvidia/pytorch or nvidia/nemo containers don't have cudf 23.12+ yet and we need the latest versions of cudf to have BytePairEncoder.