### PR TITLE
Add  MANIFEST.in to ensure clean builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+# Include all files in the requirements directory
+recursive-include requirements *.txt
+
+include README.md


### PR DESCRIPTION
This PR allows use to cleanly build wheels. 

```
python -m build .
```

Without this fix  we get below: 

```
 FileNotFoundError: [Errno 2] No such file or directory: '/tmp/build-via-sdist-nc3b67_n/crossfit-0.0.3/requirements/dev.txt'. Looks like setup.py makes some assumptions about paths maybe?
 ```
