### PR TITLE
Deduplicate columns to select in `add_keep_cols`

### DIFF
--- a/crossfit/op/base.py
+++ b/crossfit/op/base.py
@@ -70,7 +70,8 @@ class Op:
                 output[col] = data[col]
 
         columns = list(output.columns)
-        output = output[self.keep_cols + columns]
+        # we use dict.fromkeys to remove duplicates and preserve order
+        output = output[list(dict.fromkeys(self.keep_cols + columns))]
 
         return output
 

--- a/crossfit/op/base.py
+++ b/crossfit/op/base.py
@@ -70,7 +70,7 @@ class Op:
                 output[col] = data[col]
 
         columns = list(output.columns)
-        # we use dict.fromkeys to remove duplicates and preserve order
+        # we use dict.fromkeys to remove duplicates and preserve order (to match _build_dask_meta behavior) 
         output = output[list(dict.fromkeys(self.keep_cols + columns))]
 
         return output

--- a/crossfit/op/base.py
+++ b/crossfit/op/base.py
@@ -70,7 +70,8 @@ class Op:
                 output[col] = data[col]
 
         columns = list(output.columns)
-        # we use dict.fromkeys to remove duplicates and preserve order (to match _build_dask_meta behavior) 
+        # we use dict.fromkeys to remove duplicates and preserve order
+        # (to match _build_dask_meta behavior)
         output = output[list(dict.fromkeys(self.keep_cols + columns))]
 
         return output


### PR DESCRIPTION
In cudf 24.10 we can't allow duplicate columns to be selected see https://github.com/rapidsai/cudf/pull/16514/files 

In our `Op.add_keep_cols` we add `list(dict.from_keys(...))` to ensure we deduplicate the columns. Originally while we were adding columns to output in the for loop, we were then concatenating  the lists `keep_cols` + `output.columns` (which already had the keep_cols because of the for loop above) which resulted in duplicates