### PR TITLE
[REVIEW] Support dict output for models 

### DIFF
--- a/crossfit/backend/torch/model.py
+++ b/crossfit/backend/torch/model.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from enum import Enum
 from typing import Any, List, Union
 
 import cudf
 import cupy as cp
+import torch
 
 from crossfit.backend.cudf.series import (
     create_list_series_from_1d_or_2d_ar,
@@ -82,7 +82,13 @@ class Model:
     def max_seq_length(self) -> int:
         raise NotImplementedError()
 
-    def get_model_output(self, all_outputs_ls, index, loader, pred_output_col) -> cudf.DataFrame:
+    def get_model_output(
+        self,
+        all_outputs_ls: List[Union[dict, torch.Tensor]],
+        index: Union[cudf.Index],
+        loader: Any,
+        pred_output_col: str,
+    ) -> cudf.DataFrame:
         # importing here to avoid cyclic import error
         from crossfit.backend.torch.loader import SortedSeqLoader
 

--- a/crossfit/backend/torch/model.py
+++ b/crossfit/backend/torch/model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 import cudf
 import cupy as cp
@@ -36,19 +36,16 @@ class Model:
         self,
         path_or_name: str,
         max_mem_gb: int = 16,
-        model_output_type: Any = ModelOutputType.NUMERIC,
+        model_output_type: Union[str, Dict[str, str]] = "numeric",
     ):
         """Initialize a Crossfit Pytorch Model Instance.
 
         Args:
             path_or_name (str): Path to the model file or the model name to load.
-            max_mem_gb (int, optional): Maximum memory in gigabytes to allocate for the model.
-                Defaults to 16.
-            model_output_type (Union[ModelOutputType, dict], optional): Specifies the type of model
-                output. Can be either ModelOutputType.NUMERIC, ModelOutputType.STRING, or a
-                dictionary mapping output names to their respective types.
-                Defaults to ModelOutputType.NUMERIC.
-
+            max_mem_gb (int): Maximum memory in gigabytes to allocate for the model.Defaults to 16.
+            model_output_type (str, dict): Specifies the type of model output. Can be either
+                "numeric" or "string". If a dictionary is provided, it maps prediction names to
+                their respective types. Defaults to "numeric".
         """
         self.path_or_name = path_or_name
         self.max_mem_gb = max_mem_gb
@@ -134,8 +131,10 @@ def _add_column_to_df(
 ) -> None:
     if model_output_type is ModelOutputType.STRING:
         _add_string_column(df, pred_output_col, all_outputs_ls)
-    else:
+    elif model_output_type is ModelOutputType.NUMERIC:
         _add_numeric_column(df, all_outputs_ls, _index, loader, pred_output_col)
+    else:
+        raise ValueError(f"Invalid model_output_type: {model_output_type}")
 
 
 def _add_string_column(

--- a/crossfit/backend/torch/model.py
+++ b/crossfit/backend/torch/model.py
@@ -118,7 +118,6 @@ def _add_numeric_column(
     )
     del all_outputs_ls
     del loader
-    print("outputs", outputs, flush=True)
     cleanup_torch_cache()
     if len(outputs.shape) == 1:
         df[pred_output_col] = cudf.Series(outputs, index=_index)

--- a/crossfit/backend/torch/model.py
+++ b/crossfit/backend/torch/model.py
@@ -104,8 +104,8 @@ class Model:
                     raise ValueError(
                         f"Invalid prediction name '{pred_name}'.\n"
                         f"Allowed prediction names: {list(self.model_output_type.keys())}\n"
-                        "Please provide a valid prediction name in the model_output_type "
-                        "dictionary."
+                        "Please provide a valid prediction name ands its datatype "
+                        "in the model_output_type dictionary."
                     )
                 model_output_type = self.model_output_type.get(pred_name, self.model_output_type)
                 _add_column_to_df(

--- a/crossfit/backend/torch/op/base.py
+++ b/crossfit/backend/torch/op/base.py
@@ -53,7 +53,7 @@ class Predictor(Op):
         else:
             self.model_output_cols = None
 
-        if pred_output_col and len(self.model_output_cols) > 1:
+        if pred_output_col and self.model_output_cols and len(self.model_output_cols) > 1:
             raise ValueError(
                 "pred_output_col can only be specified when model_output_cols has a single column."
             )

--- a/crossfit/backend/torch/op/base.py
+++ b/crossfit/backend/torch/op/base.py
@@ -87,6 +87,13 @@ class Predictor(Op):
             if isinstance(output, dict):
                 if self.model_output_cols:
                     output = {col: output[col] for col in self.model_output_cols if col in output}
+                    if len(output) == 0:
+                        raise ValueError(
+                            "None of the specified model_output_cols were found in",
+                            "the output dict. ",
+                            f"Available output keys: {list(output.keys())}. ",
+                            f"Requested columns: {self.model_output_cols}",
+                        )
                 if len(output) == 1:
                     output = list(output.values())[0]
                 elif len(output) > 1 and self.model_output_cols is None:

--- a/crossfit/op/base.py
+++ b/crossfit/op/base.py
@@ -29,7 +29,7 @@ class Op:
 
     @property
     def worker_name(self):
-        return getattr(self.get_worker(), "name", 0)
+        return getattr(self.get_worker(), "worker_address")
 
     def setup(self):
         pass
@@ -59,7 +59,6 @@ class Op:
     def create_progress_bar(self, total, partition_info=None, **kwargs):
         return tqdm(
             total=total,
-            position=int(self.worker_name),
             desc=f"GPU: {self.worker_name}, Part: {partition_info['number']}",
             **kwargs,
         )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 from setuptools import find_packages, setup
 
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 
 
 def get_long_description():

--- a/tests/backend/pytorch_backend/test_torch_ops.py
+++ b/tests/backend/pytorch_backend/test_torch_ops.py
@@ -52,7 +52,7 @@ class DummyModel(torch.nn.Module):
         super().__init__()
 
     def forward(self, batch):
-        output_size = len(batch)
+        output_size = len(batch["input_ids"])
         return {
             "a": torch.ones(output_size, device="cuda") * 1,
             "b": torch.ones(output_size, device="cuda") * 2,

--- a/tests/backend/pytorch_backend/test_torch_ops.py
+++ b/tests/backend/pytorch_backend/test_torch_ops.py
@@ -105,7 +105,6 @@ class TestPredictorMeta:
         predictor = cf.op.Predictor(
             model=self.model_string, model_output_cols=["a"], pred_output_col="pred_a"
         )
-        print(predictor.meta())
         expected_output = {"pred_a": "object"}
         assert predictor.meta() == expected_output
 


### PR DESCRIPTION
This PR adds support for models that give dictionary output. 

Other changes include:

- Bump up CF version
- Add worker address (to fix bug on SLURM)



Main takeaway is support below model: 

```python3
class DummyModel(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, batch):
        output_size = len(batch)
        return {
            "a": torch.ones(output_size, device="cuda") * 1,
            "b": torch.ones(output_size, device="cuda") * 2,
        }

```