### PR TITLE
Remove pynmvl as dependency from base

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,3 @@ typing_extensions
 typing_utils
 tqdm
 rich
-pynvml>=11.0.0,<11.5


### PR DESCRIPTION
Given `pynvml` is a dependency of [dask_cuda](https://github.com/rapidsai/dask-cuda/blob/55d8c392ae0ecb5a9f66c41614a00f56600771ca/pyproject.toml#L23) we should remove it from `base`. And then we can just rely on `[cuda12x]` installation to resolve which `pynvml`

Currently dask_cuda uses pynvml 12 which results in a conflict during installation https://github.com/rapidsai/dask-cuda/pull/1419