### PR TITLE
Update Python, RAPIDS, and PyTorch versions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/cf_backends.yml
+++ b/.github/workflows/cf_backends.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
-        torch-version: ["~=1.11.0", "~=1.12.0", "~=1.13.0"]
+        torch-version: ["~=2.7.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/base:25.04-cuda12.8-py3.11"
+      container_image: "rapidsai/base:25.06-cuda12.8-py3.13"
       run_script: "ci/test_gpu.sh"
 
   # benchmark:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: pip
     - name: Install dependencies & Build
       run: |

--- a/conda/environments/cuda_dev.yaml
+++ b/conda/environments/cuda_dev.yaml
@@ -7,17 +7,17 @@ dependencies:
   - bandit
   - black
   - cuda-version=12.0
-  - cudf>=25.02
-  - cuml>=25.02
-  - cupy>=12.0.0
-  - cuvs>=25.02
-  - dask-cuda>=25.02
-  - dask-cudf>=25.02
+  - cudf>=25.06
+  - cuml>=25.06
+  - cupy>=13.0.0
+  - cuvs>=25.06
+  - dask-cuda>=25.06
+  - dask-cudf>=25.06
   - flake8
   - isort
   - pip
   - pre_commit
-  - pylibraft>=25.02
+  - pylibraft>=25.06
   - pytest
   - pytest-benchmark
   - pytest-cov>=2

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,6 @@
-FROM nvcr.io/nvidia/nemo:23.10
+FROM nvcr.io/nvidia/nemo:25.04
+
+# TODO: Move away from NeMo Framework container
 
 COPY . /tmp/crossfit/
 RUN cd /tmp/crossfit && \

--- a/requirements/cuda12x.txt
+++ b/requirements/cuda12x.txt
@@ -1,10 +1,10 @@
-cudf-cu12>=24.4
-dask-cudf-cu12>=24.4
-cuml-cu12>=24.4
-pylibraft-cu12>=24.4
-raft-dask-cu12>=24.4
-cuvs-cu12>=24.4
-dask-cuda>=24.6
+cudf-cu12>=25.6
+dask-cudf-cu12>=25.6
+cuml-cu12>=25.6
+pylibraft-cu12>=25.6
+raft-dask-cu12>=25.6
+cuvs-cu12>=25.6
+dask-cuda>=25.6
 torch>=2.0
 transformers>=4.0
 curated-transformers>=1.0

--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,4 +1,4 @@
-torch>=1.0
+torch>=2.0
 transformers
 curated-transformers
 bitsandbytes

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA CORPORATION
+# Copyright 2025 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,6 +78,6 @@ setup(
         **dev_requirements,
         "all": list(itertools.chain(*list(requirements.values()))),
     },
-    python_requires=">=3.10, <3.13",
+    python_requires=">=3.10, <3.14",
     test_suite="tests",
 )


### PR DESCRIPTION
The newest RAPIDS version 25.06 supports Python 3.13, testing our CI to see if we can upgrade. Updated stale PyTorch dependencies too.

Closes https://github.com/rapidsai/crossfit/issues/128.